### PR TITLE
Feature/ccta/aembootcamp 006

### DIFF
--- a/core/src/main/java/com/aembootcamp/core/models/BreadcrumbModel.java
+++ b/core/src/main/java/com/aembootcamp/core/models/BreadcrumbModel.java
@@ -1,0 +1,33 @@
+package com.aembootcamp.core.models;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+
+@Model(adaptables = Resource.class, resourceType = BreadcrumbModel.RESOURCE_TYPE, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class BreadcrumbModel {
+
+    protected static final String RESOURCE_TYPE = "aem-bootcamp/components/structure/breadcrumb";
+
+    @SlingObject
+    private Resource currentResource;
+
+    @SlingObject
+    private ResourceResolver resourceResolver;
+
+    public boolean isHomePath() {
+        PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
+        if (pageManager != null) {
+            Page currentPage = pageManager.getContainingPage(currentResource);
+            if (currentPage != null) {
+                String pagePath = currentPage.getPath();
+                return pagePath != null && pagePath.endsWith("/home");
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/com/aembootcamp/core/models/HeaderModel.java
+++ b/core/src/main/java/com/aembootcamp/core/models/HeaderModel.java
@@ -1,0 +1,77 @@
+package com.aembootcamp.core.models;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.ChildResource;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import javax.annotation.PostConstruct;
+import com.day.cq.wcm.api.Page;
+
+@Model(adaptables = { Resource.class }, resourceType = {
+        HeaderModel.RESOURCE_TYPE }, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class HeaderModel {
+
+    protected static final String RESOURCE_TYPE = "aem-bootcamp/components/structure/header";
+
+    @ValueMapValue
+    private String fileReference;
+
+    @ValueMapValue
+    private String altText;
+
+    @ValueMapValue
+    private String logoLink;
+
+    @ChildResource(injectionStrategy = InjectionStrategy.DEFAULT)
+    private Resource navigations;
+
+    public List<Page> headerNavigationItemsList;
+
+    @SlingObject
+    private ResourceResolver resourceResolver;
+
+    @PostConstruct
+    private void init() {
+
+        if (navigations != null) {
+            headerNavigationItemsList = new ArrayList<>();
+
+            Iterator<Resource> children = navigations.listChildren();
+
+            while (children.hasNext()) {
+                Resource childResource = children.next();
+                ValueMap properties = childResource.adaptTo(ValueMap.class);
+                String rootPath = properties.get("rootPath", String.class);
+
+                Page navPage = resourceResolver.getResource(rootPath).adaptTo(Page.class);
+                headerNavigationItemsList.add(navPage);
+            }
+        }
+    }
+
+    public String getFileReference() {
+        return fileReference;
+    }
+
+    public String getAltText() {
+        return altText;
+    }
+
+    public String getLogoLink() {
+        return logoLink;
+
+    }
+
+    public List<Page> getHeaderNavigationItemsList() {
+        return headerNavigationItemsList;
+    }
+
+}

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Breadcrumb"
+    jcr:description="TThis is breadcrumb component for AEM./"
+    sling:resourceSuperType="core/wcm/components/breadcrumb/v1/breadcrumb"
+    componentGroup="AEM Bootcamp Site - Structure"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/breadcrumb.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/breadcrumb.html
@@ -1,0 +1,18 @@
+<sly data-sly-use.breadcrumb="com.aembootcamp.core.models.BreadcrumbModel" />
+<sly data-sly-test="${!breadcrumb.isHomePath}">
+  <ol
+    class="cmp-breadcrumb__list"
+    data-sly-use.breadcrumb="com.adobe.cq.wcm.core.components.models.Breadcrumb"
+    data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+    data-sly-list.navItem="${breadcrumb.items}"
+  >
+    <li class="cmp-breadcrumb__item ${navItem.active ? 'active' : ''}">
+      <a class="cmp-breadcrumb__item-link" href="${navItem.URL}" data-sly-unwrap="${navItem.active}"
+        >${navItem.title}</a
+      >
+    </li>
+  </ol>
+</sly>
+<sly
+  data-sly-call="${template.placeholder @ isEmpty=breadcrumb.items.size == 0}"
+></sly>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/header/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/header/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    jcr:description="This is header navigation component for AEM Bootcamp site."
+    jcr:primaryType="cq:Component"
+    jcr:title="Header"
+    componentGroup="AEM Bootcamp Site - Structure"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/header/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/header/_cq_dialog/.content.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Header"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[aem-bootcamp.multifield.max]">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs">
+                <items jcr:primaryType="nt:unstructured">
+                    <logoTab
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Logo"
+                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+                            <image
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Image"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <file
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/foundation/form/fileupload"
+                                                autoStart="{Boolean}true"
+                                                cq-msm-lockable="/file"
+                                                fieldLabel="Upload files"
+                                                fileNameParameter="./file"
+                                                mimeTypes="[image/*]"
+                                                multiple="{Boolean}false"
+                                                name="./file"
+                                                required="{Boolean}true"
+                                                sizeLimit="100000000"
+                                                text="Upload file"
+                                                uploadUrl="/content/dam"
+                                                uploadUrlBuilder="\0"/>
+                                            <altText
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Textual alternative of the meaning or function of the image, for visually impaired readers."
+                                                fieldLabel="Alt Text"
+                                                name="./altText"
+                                                required="{Boolean}true"
+                                                wrapperClass="cmp-image--editor-alt"/>
+                                            <logoLink
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                fieldDescription="Make the image a link to another resource."
+                                                fieldLabel="Logo Link"
+                                                name="./logoLink"
+                                                nodeTypes="dam:Asset, nt:file, cq:Page"
+                                                required="{Boolean}true"
+                                                rootPath="/content"
+                                                wrapperClass="cmp-image--editor-link"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </image>
+                        </items>
+                    </logoTab>
+                    <navItemsTab
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Nav Items"
+                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+                            <navigations
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                composite="{Boolean}true"
+                                fieldLabel="Primary Navigation"
+                                validation="multifield-max-6">
+                                <field
+                                    granite:class="cmp-teaser__editor-action"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                                    fieldLabel="Primary Navigation"
+                                    name="./navigations">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <rootPath
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                            fieldLabel="Root Path"
+                                            name="./rootPath"
+                                            required="{Boolean}true"
+                                            rootPath="/content"/>
+                                    </items>
+                                </field>
+                            </navigations>
+                        </items>
+                    </navItemsTab>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/header/header.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/header/header.html
@@ -1,0 +1,39 @@
+<sly
+  data-sly-use.header="com.aembootcamp.core.models.HeaderModel"
+  data-sly-test.empty="${!header.fileReference}"
+  data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+  data-sly-call="${template.placeholder @ isEmpty=empty}"
+/>
+<sly data-sly-test="${!empty}">
+  <header class="cmp-layoutcontainer--header">
+    <div class="image cmp-image--logo">
+      <div class="cmp-image">
+        <a href="${header.logoLink @extension='html'}">
+          <img
+            src="${header.fileReference}"
+            loading="lazy"
+            class="cmp-image__image"
+            alt="${header.altText @ context='text'}"
+          />
+        </a>
+      </div>
+    </div>
+    <div class="navigation cmp-navigation--header">
+      <nav class="cmp-navigation">
+        <ul class="cmp-navigation__group">
+          <li
+            data-sly-repeat.navItems="${header.headerNavigationItemsList}"
+            class="cmp-navigation__item cmp-navigation__item--level-0 ${navItems.path == currentPage.path ? 'cmp-navigation__item--active' : ''}"
+          >
+            <a
+              href="${navItems.path @extension='html'}"
+              data-cmp-clickable=""
+              class="cmp-navigation__item-link"
+              >${navItems.title}</a
+            >
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+</sly>

--- a/ui.frontend/src/main/webpack/components/_breadcrumb.scss
+++ b/ui.frontend/src/main/webpack/components/_breadcrumb.scss
@@ -1,5 +1,20 @@
 .cmp-breadcrumb {}
-.cmp-breadcrumb__list {}
-.cmp-breadcrumb__item {}
+.cmp-breadcrumb__list {
+    display: flex;
+    column-gap: 5px;
+    list-style: none;
+}
+.cmp-breadcrumb__item {
+    text-transform: uppercase;
+    font-weight: $font-semibold;
+}
 .cmp-breadcrumb__item--active {}
-.cmp-breadcrumb__item-link {}
+.cmp-breadcrumb__item-link {
+    text-decoration: none;
+}
+
+.cmp-breadcrumb__item-link::after {
+    content: "▶";
+    color: red;
+    margin-left: 5px;
+}

--- a/ui.frontend/src/main/webpack/components/_header.scss
+++ b/ui.frontend/src/main/webpack/components/_header.scss
@@ -1,0 +1,52 @@
+.cmp-layoutcontainer--header {
+  display: flex;
+  background-color: $color-white;
+
+  .cmp-image--logo {
+    flex: 1;
+    margin: auto;
+    padding-left: 20px;
+
+    .cmp-image {
+      width: 100px;
+    }
+  }
+
+  .cmp-navigation--header {
+    flex: 1;
+
+    .cmp-navigation__group {
+      display: flex;
+      padding: 0;
+      list-style: none;
+      column-gap: 5px;
+    }
+
+    .cmp-navigation__item {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-width: 100px;
+      height: 40px;
+      color: $color-foreground;
+      text-transform: uppercase;
+      padding: 0 5px;
+    }
+
+    .cmp-navigation__item-link {
+      text-decoration: none;
+    }
+
+    .cmp-navigation__item--active {
+      background-color: $color-primary;
+
+      .cmp-navigation__item-link {
+        color: $color-white;
+      }
+    }
+
+    .cmp-navigation__item:hover .cmp-navigation__item-link {
+      border-bottom: $color-primary 2px solid;
+    }
+  }
+}

--- a/ui.frontend/src/main/webpack/site/_variables.scss
+++ b/ui.frontend/src/main/webpack/site/_variables.scss
@@ -5,6 +5,10 @@ $font-family:           "Helvetica Neue", Helvetica, Arial, sans-serif;
 $font-size:             16px;
 $font-height:           1.5;
 
+//== Font Styles
+$font-semibold: 600;
+$font-bold: 700;
+
 //== Color
 $color-white:           #FFFFFF;
 

--- a/ui.frontend/src/main/webpack/site/_variables.scss
+++ b/ui.frontend/src/main/webpack/site/_variables.scss
@@ -6,13 +6,15 @@ $font-size:             16px;
 $font-height:           1.5;
 
 //== Color
+$color-white:           #FFFFFF;
 
 // Normal mode
 $color-foreground:      #202020;
 $color-background:      #ECECEC;
-$color-link:            #2020E0;
+$color-link:            $color-foreground;
+$color-primary:         #ff0000;
 
 // Dark mode
-$color-foreground-dark: invert($color-foreground);
-$color-background-dark: invert($color-background);
-$color-link-dark:       invert($color-link);
+$color-foreground-dark: $color-foreground;
+$color-background-dark: $color-background;
+$color-link-dark:       $color-link;


### PR DESCRIPTION
Breadcrumb Component

Extended from Breadcrumb V1
- Breadcrumb links should be clickable and take the user to the respective page
when clicked.
- If hideInNav property is set to true, then page should not visible in breadcrumb
hierarchy.
- Breadcrumb should always have Homepage as first item.
- Fetch homepage dynamically with the help of homepage template


<img width="1260" alt="Breadcrumb" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/bd8a4f04-e2f8-4d4b-965e-4b15e66fd1d7">

- Breadcrumb should not display in homepage
<img width="1261" alt="Breadcrumb Home" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/a4769fe2-1d07-46ba-af7f-bfbab4ae6b3d">

- Breadcrumb should prioritize navigation title then page title then jcr:title.
<img width="1245" alt="Breadcrumb preferences" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/c053aa25-2e65-43d6-8972-bcbe17020456">
