### PR TITLE
Feature/ccta/aembootcamp 06

### DIFF
--- a/core/src/main/java/com/aembootcamp/core/models/BreadcrumbModel.java
+++ b/core/src/main/java/com/aembootcamp/core/models/BreadcrumbModel.java
@@ -1,15 +1,21 @@
 package com.aembootcamp.core.models;
 
+import com.adobe.cq.wcm.core.components.models.Breadcrumb;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
+
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.Via;
+import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.via.ResourceSuperType;
+import lombok.experimental.Delegate;
 
-@Model(adaptables = Resource.class, resourceType = BreadcrumbModel.RESOURCE_TYPE, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
-public class BreadcrumbModel {
+@Model(adaptables = SlingHttpServletRequest.class, adapters = Breadcrumb.class, resourceType = BreadcrumbModel.RESOURCE_TYPE)
+public class BreadcrumbModel implements Breadcrumb {
 
     protected static final String RESOURCE_TYPE = "aem-bootcamp/components/structure/breadcrumb";
 
@@ -18,6 +24,9 @@ public class BreadcrumbModel {
 
     @SlingObject
     private ResourceResolver resourceResolver;
+
+    @Delegate @Self @Via(type = ResourceSuperType.class)
+    private Breadcrumb breadcrumb;
 
     public boolean isHomePath() {
         PageManager pageManager = resourceResolver.adaptTo(PageManager.class);

--- a/core/src/main/java/com/aembootcamp/core/models/BreadcrumbModel.java
+++ b/core/src/main/java/com/aembootcamp/core/models/BreadcrumbModel.java
@@ -2,40 +2,33 @@ package com.aembootcamp.core.models;
 
 import com.adobe.cq.wcm.core.components.models.Breadcrumb;
 import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageManager;
 
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Via;
 import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.via.ResourceSuperType;
 import lombok.experimental.Delegate;
+
+import javax.inject.Inject;
 
 @Model(adaptables = SlingHttpServletRequest.class, adapters = Breadcrumb.class, resourceType = BreadcrumbModel.RESOURCE_TYPE)
 public class BreadcrumbModel implements Breadcrumb {
 
     protected static final String RESOURCE_TYPE = "aem-bootcamp/components/structure/breadcrumb";
 
-    @SlingObject
-    private Resource currentResource;
+    @Inject
+    private Page currentPage;
 
-    @SlingObject
-    private ResourceResolver resourceResolver;
-
-    @Delegate @Self @Via(type = ResourceSuperType.class)
+    @Delegate
+    @Self
+    @Via(type = ResourceSuperType.class)
     private Breadcrumb breadcrumb;
 
-    public boolean isHomePath() {
-        PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
-        if (pageManager != null) {
-            Page currentPage = pageManager.getContainingPage(currentResource);
-            if (currentPage != null) {
-                String pagePath = currentPage.getPath();
-                return pagePath != null && pagePath.endsWith("/home");
-            }
+    public boolean isHomePage() {
+        if (currentPage != null) {
+            String templateName = currentPage.getTemplate().getName();
+            return templateName != null && templateName.equals("homepage");
         }
         return false;
     }

--- a/core/src/main/java/com/aembootcamp/core/models/BreadcrumbModel.java
+++ b/core/src/main/java/com/aembootcamp/core/models/BreadcrumbModel.java
@@ -1,0 +1,33 @@
+package com.aembootcamp.core.models;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+
+@Model(adaptables = Resource.class, resourceType = BreadcrumbModel.RESOURCE_TYPE, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class BreadcrumbModel {
+
+    protected static final String RESOURCE_TYPE = "aem-bootcamp/components/structure/breadcrumb";
+
+    @SlingObject
+    private Resource currentResource;
+
+    @SlingObject
+    private ResourceResolver resourceResolver;
+
+    public boolean isHomePath() {
+        PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
+        if (pageManager != null) {
+            Page currentPage = pageManager.getContainingPage(currentResource);
+            if (currentPage != null) {
+                String pagePath = currentPage.getPath();
+                return pagePath != null && pagePath.endsWith("/home");
+            }
+        }
+        return false;
+    }
+}

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/breadcrumb/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/breadcrumb/.content.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="cq:Component"
-    jcr:title="Breadcrumb"
-    sling:resourceSuperType="core/wcm/components/breadcrumb/v3/breadcrumb"
-    componentGroup="AEM Bootcamp Site - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/.content.xml
@@ -2,6 +2,6 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Breadcrumb"
-    jcr:description="TThis is breadcrumb component for AEM./"
+    jcr:description="This is breadcrumb component for AEM./"
     sling:resourceSuperType="core/wcm/components/breadcrumb/v1/breadcrumb"
     componentGroup="AEM Bootcamp Site - Structure"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Breadcrumb"
+    jcr:description="TThis is breadcrumb component for AEM./"
+    sling:resourceSuperType="core/wcm/components/breadcrumb/v1/breadcrumb"
+    componentGroup="AEM Bootcamp Site - Structure"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/breadcrumb.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/breadcrumb.html
@@ -1,5 +1,5 @@
 <sly data-sly-use.breadcrumb="com.aembootcamp.core.models.BreadcrumbModel" />
-<sly data-sly-test="${!breadcrumb.isHomePath}">
+<sly data-sly-test="${!breadcrumb.homePage}">
   <ol
     class="cmp-breadcrumb__list"
     data-sly-use.template="core/wcm/components/commons/v1/templates.html"

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/breadcrumb.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/breadcrumb.html
@@ -1,0 +1,18 @@
+<sly data-sly-use.breadcrumb="com.aembootcamp.core.models.BreadcrumbModel" />
+<sly data-sly-test="${!breadcrumb.isHomePath}">
+  <ol
+    class="cmp-breadcrumb__list"
+    data-sly-use.breadcrumb="com.adobe.cq.wcm.core.components.models.Breadcrumb"
+    data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+    data-sly-list.navItem="${breadcrumb.items}"
+  >
+    <li class="cmp-breadcrumb__item ${navItem.active ? 'active' : ''}">
+      <a class="cmp-breadcrumb__item-link" href="${navItem.URL}" data-sly-unwrap="${navItem.active}"
+        >${navItem.title}</a
+      >
+    </li>
+  </ol>
+</sly>
+<sly
+  data-sly-call="${template.placeholder @ isEmpty=breadcrumb.items.size == 0}"
+></sly>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/breadcrumb.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/breadcrumb/breadcrumb.html
@@ -2,12 +2,14 @@
 <sly data-sly-test="${!breadcrumb.isHomePath}">
   <ol
     class="cmp-breadcrumb__list"
-    data-sly-use.breadcrumb="com.adobe.cq.wcm.core.components.models.Breadcrumb"
     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
     data-sly-list.navItem="${breadcrumb.items}"
   >
     <li class="cmp-breadcrumb__item ${navItem.active ? 'active' : ''}">
-      <a class="cmp-breadcrumb__item-link" href="${navItem.URL}" data-sly-unwrap="${navItem.active}"
+      <a
+        class="cmp-breadcrumb__item-link"
+        href="${navItem.URL}"
+        data-sly-unwrap="${navItem.active}"
         >${navItem.title}</a
       >
     </li>

--- a/ui.frontend/src/main/webpack/components/_breadcrumb.scss
+++ b/ui.frontend/src/main/webpack/components/_breadcrumb.scss
@@ -1,5 +1,20 @@
-.cmp-breadcrumb {}
-.cmp-breadcrumb__list {}
-.cmp-breadcrumb__item {}
-.cmp-breadcrumb__item--active {}
-.cmp-breadcrumb__item-link {}
+.cmp-breadcrumb__list {
+    display: flex;
+    column-gap: 5px;
+    list-style: none;
+}
+
+.cmp-breadcrumb__item {
+    text-transform: uppercase;
+    font-weight: $font-semibold;
+}
+
+.cmp-breadcrumb__item-link {
+    text-decoration: none;
+}
+
+.cmp-breadcrumb__item-link::after {
+    content: "▶";
+    color: red;
+    margin-left: 5px;
+}

--- a/ui.frontend/src/main/webpack/components/_breadcrumb.scss
+++ b/ui.frontend/src/main/webpack/components/_breadcrumb.scss
@@ -6,15 +6,15 @@
 
 .cmp-breadcrumb__item {
     text-transform: uppercase;
-    font-weight: $font-semibold;
 }
 
 .cmp-breadcrumb__item-link {
     text-decoration: none;
+    font-weight: $font-semibold;
 }
 
 .cmp-breadcrumb__item-link::after {
     content: "▶";
-    color: red;
+    color: $color-primary;
     margin-left: 5px;
 }

--- a/ui.frontend/src/main/webpack/site/_variables.scss
+++ b/ui.frontend/src/main/webpack/site/_variables.scss
@@ -5,6 +5,10 @@ $font-family:           "Helvetica Neue", Helvetica, Arial, sans-serif;
 $font-size:             16px;
 $font-height:           1.5;
 
+//== Font Styles
+$font-semibold: 600;
+$font-bold: 700;
+
 //== Color
 $color-white:           #FFFFFF;
 


### PR DESCRIPTION
Breadcrumb Component

Extended from Breadcrumb V1
- Breadcrumb links should be clickable and take the user to the respective page
when clicked.
- If hideInNav property is set to true, then page should not visible in breadcrumb
hierarchy.
- Breadcrumb should always have Homepage as first item.
- Fetch homepage dynamically with the help of homepage template


<img width="1260" alt="Breadcrumb" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/bd8a4f04-e2f8-4d4b-965e-4b15e66fd1d7">

- Breadcrumb should not display in homepage
<img width="1261" alt="Breadcrumb Home" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/a4769fe2-1d07-46ba-af7f-bfbab4ae6b3d">

- Breadcrumb should prioritize navigation title then page title then jcr:title.
<img width="1245" alt="Breadcrumb preferences" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/c053aa25-2e65-43d6-8972-bcbe17020456">
