### PR TITLE
Feat: AEM Bootcamp 009 - Add Image component with Alt, Asset and Link

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:description="This is Image component for AEM Bootcamp sites."
+    jcr:primaryType="cq:Component"
+    jcr:title="Image"
+    sling:resourceSuperType="core/wcm/components/image/v2/image"
+    componentGroup="AEM Bootcamp Site - General"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/_cq_dialog/.content.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Image"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[core.wcm.components.image.v2.editor]"
+    helpPath="https://www.adobe.com/go/aem_cmp_image_v2"
+    trackingFeature="core-components:image:v2">
+    <content
+        granite:class="cmp-image__editor"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                maximized="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <asset
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Asset"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <file
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/authoring/dialog/fileupload"
+                                                class="cq-droptarget"
+                                                fileNameParameter="./fileName"
+                                                fileReferenceParameter="./fileReference"
+                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
+                                                name="./file"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </asset>
+                    <metadata
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Metadata"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <alternativeGroup
+                                                granite:class="cmp-image__editor-alt"
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/well">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <alt
+                                                        granite:class="cmp-image__editor-alt-text"
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                        fieldDescription="Textual alternative of the meaning or function of the image, for visually impaired readers."
+                                                        fieldLabel="Alternative Text"
+                                                        name="./alt"
+                                                        required="{Boolean}true"/>
+                                                    <altValueFromDAM
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:hideResource="true"/>
+                                                </items>
+                                            </alternativeGroup>
+                                            <captionGroup
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:hideResource="true">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <caption jcr:primaryType="nt:unstructured"/>
+                                                    <titleValueFromDAM jcr:primaryType="nt:unstructured"/>
+                                                    <displayPopupTitle jcr:primaryType="nt:unstructured"/>
+                                                </items>
+                                            </captionGroup>
+                                            <decorative
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:hideResource="true"/>
+                                            <linkURL
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                fieldDescription="Make the image a link to another resource."
+                                                fieldLabel="Link"
+                                                name="./linkURL"
+                                                nodeTypes="dam:Asset, nt:file, cq:Page"
+                                                rootPath="/content"
+                                                wrapperClass="cmp-image__editor-link"/>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:hideResource="true"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </metadata>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/image/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/image/.content.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="cq:Component"
-    jcr:title="Image"
-    sling:resourceSuperType="core/wcm/components/image/v3/image"
-    componentGroup="AEM Bootcamp Site - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/image/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/image/_cq_editConfig.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:inherit="{Boolean}true"
-    jcr:primaryType="cq:EditConfig"/>


### PR DESCRIPTION
### Screenshot

- Asset tab

![image](https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170549105/6695873f-7c39-494f-99ad-194cf27afe5a)

---

- Metadata Tab

![image](https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170549105/8a644358-6231-42df-bb19-a68b88291c21)


