### PR TITLE
aembootcamp-010: Separator

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/.content.xml
@@ -2,5 +2,6 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Separator"
+    jcr:description="This is Separator component for AEM Bootcamp sites."
     sling:resourceSuperType="core/wcm/components/separator/v1/separator"
-    componentGroup="AEM Bootcamp Site - Content"/>
+    componentGroup="AEM Bootcamp Site - General"/>

--- a/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/policies/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:mixinTypes="[rep:AccessControllable]"
     jcr:primaryType="cq:Page">
     <rep:policy/>
@@ -34,11 +34,11 @@
                     jcr:title="Content Image"
                     sling:resourceType="wcm/core/components/policy/policy"
                     allowedRenditionWidths="[320,480,600,800,1024,1200,1600]"
-                    disableLazyLoading="false"
-                    enableAssetDelivery="true"
                     allowUpload="false"
                     altValueFromDAM="true"
+                    disableLazyLoading="false"
                     displayPopupTitle="true"
+                    enableAssetDelivery="true"
                     isDecorative="false"
                     jpegQuality="{Long}85"
                     titleValueFromDAM="true"
@@ -238,10 +238,13 @@
                 </policy_1574694950110>
                 <policy_1574695586800
                     jcr:description="Allows the page components and defines the component mapping (this configures what components should be automatically created when authors drop assets from the content finder to the page editor)."
+                    jcr:lastModified="{Date}2024-05-23T15:16:56.247-05:00"
+                    jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Page Content"
                     sling:resourceType="wcm/core/components/policy/policy"
-                    components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container]">
+                    components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container,group:AEM Bootcamp Site - Structure]"
+                    layoutDisabled="false">
                     <jcr:content jcr:primaryType="nt:unstructured"/>
                     <cq:authoring jcr:primaryType="nt:unstructured">
                         <assetToComponentMapping jcr:primaryType="nt:unstructured">
@@ -276,10 +279,13 @@
                 </policy_649128221558427>
                 <policy_1575040440977
                     jcr:description="Allows the template components and defines the component mapping (this configures what components should be automatically created when authors drop assets from the content finder to the page editor)."
+                    jcr:lastModified="{Date}2024-06-04T17:45:05.437-05:00"
+                    jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     jcr:title="XF Root"
                     sling:resourceType="wcm/core/components/policy/policy"
-                    components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container]">
+                    components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container,/apps/aem-bootcamp/components/general/separator,/apps/aem-bootcamp/components/structure/header,/apps/aem-bootcamp/components/navigation]"
+                    layoutDisabled="false">
                     <jcr:content jcr:primaryType="nt:unstructured"/>
                     <cq:authoring jcr:primaryType="nt:unstructured">
                         <assetToComponentMapping jcr:primaryType="nt:unstructured">
@@ -340,14 +346,95 @@
                     <jcr:content jcr:primaryType="nt:unstructured"/>
                 </policy>
             </page>
+            <general jcr:primaryType="nt:unstructured">
+                <separator jcr:primaryType="nt:unstructured">
+                    <policy_1717593874725
+                        jcr:lastModified="{Date}2024-06-05T09:29:14.798-05:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Footer Separator"
+                        sling:resourceType="wcm/core/components/policy/policy"
+                        isDecorative="false">
+                        <jcr:content jcr:primaryType="nt:unstructured"/>
+                        <cq:styleGroups jcr:primaryType="nt:unstructured">
+                            <item0
+                                cq:styleGroupLabel="Color"
+                                jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0
+                                        cq:styleClasses="cmp-separator__grey"
+                                        cq:styleId="1717593927884"
+                                        cq:styleLabel="Grey"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item1
+                                        cq:styleClasses="cmp-separator__black"
+                                        cq:styleId="1717594075074"
+                                        cq:styleLabel="Black"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item2
+                                        cq:styleClasses="cmp-separator__white"
+                                        cq:styleId="1717594082345"
+                                        cq:styleLabel="White"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item3
+                                        cq:styleClasses="cmp-separator__yellow"
+                                        cq:styleId="1717594091961"
+                                        cq:styleLabel="Yellow"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item4
+                                        cq:styleClasses="cmp-separator__red"
+                                        cq:styleId="1717594100742"
+                                        cq:styleLabel="Red"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item5
+                                        cq:styleClasses="cmp-separator__blue"
+                                        cq:styleId="1717594106327"
+                                        cq:styleLabel="Blue"
+                                        jcr:primaryType="nt:unstructured"/>
+                                </cq:styles>
+                            </item0>
+                            <item1
+                                cq:styleGroupLabel="Thickness"
+                                jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0
+                                        cq:styleClasses="cmp-separator__thin"
+                                        cq:styleId="1717594136161"
+                                        cq:styleLabel="Thin"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item1
+                                        cq:styleClasses="cmp-separator__thick"
+                                        cq:styleId="1717594143499"
+                                        cq:styleLabel="Thick"
+                                        jcr:primaryType="nt:unstructured"/>
+                                </cq:styles>
+                            </item1>
+                            <item2
+                                cq:styleGroupLabel="Style"
+                                jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0
+                                        cq:styleClasses="cmp-separator__dashed"
+                                        cq:styleId="1717594210292"
+                                        cq:styleLabel="Dashed"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item1
+                                        cq:styleClasses="cmp-separator__dotted"
+                                        cq:styleId="1717594221035"
+                                        cq:styleLabel="Dotted"
+                                        jcr:primaryType="nt:unstructured"/>
+                                </cq:styles>
+                            </item2>
+                        </cq:styleGroups>
+                    </policy_1717593874725>
+                </separator>
+            </general>
         </components>
     </aem-bootcamp>
     <wcm jcr:primaryType="nt:unstructured">
         <foundation jcr:primaryType="nt:unstructured">
             <components jcr:primaryType="nt:unstructured">
-                <responsivegrid jcr:primaryType="nt:unstructured">
-            
-                </responsivegrid>
+                <responsivegrid jcr:primaryType="nt:unstructured"/>
             </components>
         </foundation>
     </wcm>

--- a/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/policies/.content.xml
@@ -205,112 +205,6 @@
                     <jcr:content jcr:primaryType="nt:unstructured"/>
                 </policy_footer>
             </experiencefragment>
-            <container jcr:primaryType="nt:unstructured">
-                <policy_1574694950110
-                    jcr:description="Allows the template components and defines the component mapping (this configures what components should be automatically created when authors drop assets from the content finder to the page editor)."
-                    jcr:primaryType="nt:unstructured"
-                    jcr:title="Page Root"
-                    sling:resourceType="wcm/core/components/policy/policy"
-                    components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container,group:AEM Bootcamp Site - Structure]">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
-                    <cq:authoring jcr:primaryType="nt:unstructured">
-                        <assetToComponentMapping jcr:primaryType="nt:unstructured">
-                            <mapping_1575024218483
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="media"
-                                assetMimetype="image/*"
-                                droptarget="image"
-                                resourceType="aem-bootcamp/components/image"/>
-                            <mapping_1575030843388
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="content"
-                                assetMimetype="text/html"
-                                droptarget="experiencefragment"
-                                resourceType="aem-bootcamp/components/experiencefragment"/>
-                            <mapping_1575030853128
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="media"
-                                assetMimetype="[text/html,application/vnd.adobe.contentfragment]"
-                                droptarget="contentfragment"
-                                resourceType="aem-bootcamp/components/contentfragment"/>
-                        </assetToComponentMapping>
-                    </cq:authoring>
-                </policy_1574694950110>
-                <policy_1574695586800
-                    jcr:description="Allows the page components and defines the component mapping (this configures what components should be automatically created when authors drop assets from the content finder to the page editor)."
-                    jcr:lastModified="{Date}2024-05-23T15:16:56.247-05:00"
-                    jcr:lastModifiedBy="admin"
-                    jcr:primaryType="nt:unstructured"
-                    jcr:title="Page Content"
-                    sling:resourceType="wcm/core/components/policy/policy"
-                    components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container,group:AEM Bootcamp Site - Structure]"
-                    layoutDisabled="false">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
-                    <cq:authoring jcr:primaryType="nt:unstructured">
-                        <assetToComponentMapping jcr:primaryType="nt:unstructured">
-                            <mapping_1575030255082
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="media"
-                                assetMimetype="image/*"
-                                droptarget="image"
-                                resourceType="aem-bootcamp/components/image"/>
-                            <mapping_1575030260142
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="content"
-                                assetMimetype="text/html"
-                                droptarget="experiencefragment"
-                                resourceType="aem-bootcamp/components/experiencefragment"/>
-                            <mapping_1575030269139
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="media"
-                                assetMimetype="[text/html,application/vnd.adobe.contentfragment]"
-                                droptarget="contentfragment"
-                                resourceType="aem-bootcamp/components/contentfragment"/>
-                        </assetToComponentMapping>
-                    </cq:authoring>
-                </policy_1574695586800>
-                <policy_649128221558427
-                    cq:styleDefaultElement="main"
-                    jcr:description="Sets a &lt;main> element on the page content area."
-                    jcr:primaryType="nt:unstructured"
-                    jcr:title="Page Main"
-                    sling:resourceType="wcm/core/components/policy/policy">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
-                </policy_649128221558427>
-                <policy_1575040440977
-                    jcr:description="Allows the template components and defines the component mapping (this configures what components should be automatically created when authors drop assets from the content finder to the page editor)."
-                    jcr:lastModified="{Date}2024-06-04T17:45:05.437-05:00"
-                    jcr:lastModifiedBy="admin"
-                    jcr:primaryType="nt:unstructured"
-                    jcr:title="XF Root"
-                    sling:resourceType="wcm/core/components/policy/policy"
-                    components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container,/apps/aem-bootcamp/components/general/separator,/apps/aem-bootcamp/components/structure/header,/apps/aem-bootcamp/components/navigation]"
-                    layoutDisabled="false">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
-                    <cq:authoring jcr:primaryType="nt:unstructured">
-                        <assetToComponentMapping jcr:primaryType="nt:unstructured">
-                            <mapping_1575024218483
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="media"
-                                assetMimetype="image/*"
-                                droptarget="image"
-                                resourceType="aem-bootcamp/components/image"/>
-                            <mapping_1575030843388
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="content"
-                                assetMimetype="text/html"
-                                droptarget="experiencefragment"
-                                resourceType="aem-bootcamp/components/experiencefragment"/>
-                            <mapping_1575030853128
-                                jcr:primaryType="nt:unstructured"
-                                assetGroup="media"
-                                assetMimetype="[text/html,application/vnd.adobe.contentfragment]"
-                                droptarget="contentfragment"
-                                resourceType="aem-bootcamp/components/contentfragment"/>
-                        </assetToComponentMapping>
-                    </cq:authoring>
-                </policy_1575040440977>
-            </container>
             <teaser jcr:primaryType="nt:unstructured">
                 <policy_1575031387650
                     jcr:description="Sets the title size to H3."
@@ -349,7 +243,7 @@
             <general jcr:primaryType="nt:unstructured">
                 <separator jcr:primaryType="nt:unstructured">
                     <policy_1717593874725
-                        jcr:lastModified="{Date}2024-06-05T09:29:14.798-05:00"
+                        jcr:lastModified="{Date}2024-06-07T15:49:39.872-05:00"
                         jcr:lastModifiedBy="admin"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Footer Separator"
@@ -358,6 +252,17 @@
                         <jcr:content jcr:primaryType="nt:unstructured"/>
                         <cq:styleGroups jcr:primaryType="nt:unstructured">
                             <item0
+                                cq:styleGroupLabel="Visibility"
+                                jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0
+                                        cq:styleClasses="cmp-separator__hide"
+                                        cq:styleId="1717793350818"
+                                        cq:styleLabel="Hide"
+                                        jcr:primaryType="nt:unstructured"/>
+                                </cq:styles>
+                            </item0>
+                            <item1
                                 cq:styleGroupLabel="Color"
                                 jcr:primaryType="nt:unstructured">
                                 <cq:styles jcr:primaryType="nt:unstructured">
@@ -392,8 +297,8 @@
                                         cq:styleLabel="Blue"
                                         jcr:primaryType="nt:unstructured"/>
                                 </cq:styles>
-                            </item0>
-                            <item1
+                            </item1>
+                            <item2
                                 cq:styleGroupLabel="Thickness"
                                 jcr:primaryType="nt:unstructured">
                                 <cq:styles jcr:primaryType="nt:unstructured">
@@ -408,8 +313,8 @@
                                         cq:styleLabel="Thick"
                                         jcr:primaryType="nt:unstructured"/>
                                 </cq:styles>
-                            </item1>
-                            <item2
+                            </item2>
+                            <item3
                                 cq:styleGroupLabel="Style"
                                 jcr:primaryType="nt:unstructured">
                                 <cq:styles jcr:primaryType="nt:unstructured">
@@ -424,7 +329,7 @@
                                         cq:styleLabel="Dotted"
                                         jcr:primaryType="nt:unstructured"/>
                                 </cq:styles>
-                            </item2>
+                            </item3>
                         </cq:styleGroups>
                     </policy_1717593874725>
                 </separator>

--- a/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/templates/xf-web-variation/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/templates/xf-web-variation/policies/.content.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
+        cq:lastModified="{Date}2024-06-05T09:29:14.814-05:00"
+        cq:lastModifiedBy="admin"
         cq:policy="aem-bootcamp/components/page/policy"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
@@ -33,6 +35,16 @@
                         sling:resourceType="wcm/core/components/policies/mapping"/>
                 </components>
             </mysite>
+            <aem-bootcamp jcr:primaryType="nt:unstructured">
+                <components jcr:primaryType="nt:unstructured">
+                    <general jcr:primaryType="nt:unstructured">
+                        <separator
+                            cq:policy="aem-bootcamp/components/general/separator/policy_1717593874725"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="wcm/core/components/policies/mapping"/>
+                    </general>
+                </components>
+            </aem-bootcamp>
         </root>
     </jcr:content>
 </jcr:root>

--- a/ui.frontend/src/main/webpack/components/_separator.scss
+++ b/ui.frontend/src/main/webpack/components/_separator.scss
@@ -5,6 +5,10 @@
 }
 
 //Footer variations
+.cmp-separator__hide {
+    display: none;
+}
+
 .cmp-separator__grey {
     .cmp-separator__horizontal-rule {
         color: $color-grey;

--- a/ui.frontend/src/main/webpack/components/_separator.scss
+++ b/ui.frontend/src/main/webpack/components/_separator.scss
@@ -1,2 +1,66 @@
-.cmp-separator {}
-.cmp-separator__horizontal-rule {}
+.cmp-separator {
+}
+.cmp-separator__horizontal-rule {
+    border-style: solid;
+}
+
+//Footer variations
+.cmp-separator__grey {
+    .cmp-separator__horizontal-rule {
+        color: $color-grey;
+    }
+}
+
+.cmp-separator__black {
+    .cmp-separator__horizontal-rule {
+        color: $color-black;
+    }
+}
+
+.cmp-separator__white {
+    .cmp-separator__horizontal-rule {
+        color: $color-white;
+    }
+}
+
+.cmp-separator__yellow {
+    .cmp-separator__horizontal-rule {
+        color: $color-yellow;
+    }
+}
+
+.cmp-separator__red {
+    .cmp-separator__horizontal-rule {
+        color: $color-red;
+    }
+}
+
+.cmp-separator__blue {
+    .cmp-separator__horizontal-rule {
+        color: $color-blue;
+    }
+}
+
+.cmp-separator__thin {
+    .cmp-separator__horizontal-rule {
+        border-width: 0.1px;
+    }
+}
+
+.cmp-separator__thick {
+    .cmp-separator__horizontal-rule {
+        border-width: 2px;
+    }
+}
+
+.cmp-separator__dashed {
+    .cmp-separator__horizontal-rule {
+        border-style: dashed;
+    }
+}
+
+.cmp-separator__dotted {
+    .cmp-separator__horizontal-rule {
+        border-style: dotted;
+    }
+}

--- a/ui.frontend/src/main/webpack/site/_variables.scss
+++ b/ui.frontend/src/main/webpack/site/_variables.scss
@@ -10,13 +10,18 @@ $font-semibold: 600;
 $font-bold: 700;
 
 //== Color
-$color-white:           #FFFFFF;
+$color-grey:            black;
+$color-black:           black;
+$color-white:           white;
+$color-yellow:          yellow;
+$color-red:             red;
+$color-blue:            blue;
 
 // Normal mode
-$color-foreground:      #202020;
-$color-background:      #ECECEC;
+$color-foreground:      $color-black;
+$color-background:      #FFFFFF;
 $color-link:            $color-foreground;
-$color-primary:         #ff0000;
+$color-primary:         $color-red;
 
 // Dark mode
 $color-foreground-dark: $color-foreground;


### PR DESCRIPTION

• Author should be able to show/hide the separator if added to page.
<img width="1758" alt="Screenshot 2024-06-07 at 3 51 36 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/11e69893-ae53-49e2-a9cc-4c1df7f651b1">

• Author should be able to change color of the separator. Colors like
    o Grey
    o Black
    o White
    o Yellow
    o Red
    o Blue
• Author should be able to change thickness of the separator.
• Author should be able to change style of separator like solid, dashed, dotted.

<img width="1258" alt="Screenshot 2024-06-07 at 3 47 02 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/af08cbfe-3b5f-4db8-a4ac-87d6772b7c86">
<img width="1263" alt="Screenshot 2024-06-07 at 3 46 43 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/25993793/f80c4645-b251-433c-8765-0c0cee10b6d5">
