### PR TITLE
Feature/srh/aembootcamp 10: Separator 

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Separator"
+    jcr:description="This is Separator component for AEM Bootcamp sites."
+    sling:resourceSuperType="core/wcm/components/separator/v1/separator"
+    componentGroup="AEM Bootcamp Site - General"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/_cq_dialog/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Separator"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    sling:hideResource="true">
+</jcr:root>

--- a/ui.frontend/src/main/webpack/components/_separator.scss
+++ b/ui.frontend/src/main/webpack/components/_separator.scss
@@ -1,2 +1,70 @@
-.cmp-separator {}
-.cmp-separator__horizontal-rule {}
+.cmp-separator {
+}
+.cmp-separator__horizontal-rule {
+  border-style: solid;
+}
+
+//Footer variations
+.cmp-separator--hide {
+  display: none;
+}
+
+.cmp-separator--grey {
+  .cmp-separator__horizontal-rule {
+    color: grey;
+  }
+}
+
+.cmp-separator--black {
+  .cmp-separator__horizontal-rule {
+    color: black;
+  }
+}
+
+.cmp-separator--white {
+  .cmp-separator__horizontal-rule {
+    color: white;
+  }
+}
+
+.cmp-separator--yellow {
+  .cmp-separator__horizontal-rule {
+    color: yellow;
+  }
+}
+
+.cmp-separator--red {
+  .cmp-separator__horizontal-rule {
+    color: red;
+  }
+}
+
+.cmp-separator--blue {
+  .cmp-separator__horizontal-rule {
+    color: blue;
+  }
+}
+
+.cmp-separator--dashed {
+  .cmp-separator__horizontal-rule {
+    border-style: dashed;
+  }
+}
+
+.cmp-separator--dotted {
+  .cmp-separator__horizontal-rule {
+    border-style: dotted;
+  }
+}
+
+.cmp-separator--thin {
+  .cmp-separator__horizontal-rule {
+    border-width: 0.1px;
+  }
+}
+
+.cmp-separator--thick {
+  .cmp-separator__horizontal-rule {
+    border-width: 2px;
+  }
+}


### PR DESCRIPTION
Author should be able to show/hide the separator if added to page.
- show
 
<img width="257" alt="Screenshot 2024-06-12 at 2 27 56 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170354505/e56f561d-1603-41cc-af57-15e1e3bf8aec">

- hide
<img width="201" alt="Screenshot 2024-06-12 at 2 28 30 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170354505/baeeb239-1677-4ea4-8bda-1285b32cab56">

Author should be able to change color of the separator. Colors like
o Grey 
o Black 
o White 
o Yellow 
o Red
o Blue

Author should be able to change style of separator like solid, dashed, dotted.
- dotted 
<img width="257" alt="Screenshot 2024-06-12 at 2 27 56 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170354505/c242879d-31d3-466a-a668-24f839f33392">

- dashed
<img width="208" alt="Screenshot 2024-06-12 at 2 30 59 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170354505/e5aeaef0-c674-4b22-adf4-4678c822de9e">

Author should be able to change thickness of the separator.
- thin
<img width="180" alt="Screenshot 2024-06-12 at 2 32 22 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170354505/127296ea-e4c3-4f38-81da-99329b98ff9f">

- thick
<img width="257" alt="Screenshot 2024-06-12 at 2 27 56 PM" src="https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170354505/b2c98c69-e989-4eb1-8904-286c95f82867">
