### PR TITLE
This Commit add a new article component

### DIFF
--- a/core/src/main/java/com/aembootcamp/core/models/ArticleModel.java
+++ b/core/src/main/java/com/aembootcamp/core/models/ArticleModel.java
@@ -1,0 +1,89 @@
+package com.aembootcamp.core.models;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+
+import com.adobe.cq.dam.cfm.ContentElement;
+import com.adobe.cq.dam.cfm.ContentFragment;
+import com.day.cq.wcm.api.Page;
+
+import java.util.Optional;
+
+import javax.annotation.PostConstruct;
+
+@Getter
+@Model(adaptables = { SlingHttpServletRequest.class }, resourceType = {
+        ArticleModel.RESOURCE_TYPE }, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class ArticleModel {
+
+    protected static final String RESOURCE_TYPE = "aem-bootcamp/components/structure/article";
+
+    @ValueMapValue
+    private String title;
+
+    @ValueMapValue
+    private String fileReference;
+
+    @ValueMapValue
+    private String description;
+
+    @Getter(AccessLevel.NONE)
+    @ValueMapValue
+    private String authorContentFragment;
+
+    @ValueMapValue
+    private String[] categories;
+    
+    @ScriptVariable(injectionStrategy = InjectionStrategy.REQUIRED)
+    private Page currentPage;
+    
+    @SlingObject
+    private ResourceResolver resourceResolver;
+
+
+    private String authorName;
+
+    private String authorDisplayPicture;
+
+    private String authorBio;
+
+    private String categoriesTagText;
+
+    @PostConstruct
+    private void init() {
+        fetchTagText();
+        fetchContentFragmentData();
+    }
+
+    private void fetchTagText() {
+        Optional<String[]> articleCategories = Optional.ofNullable((String[]) currentPage.getProperties().get("articlecategories"));
+        categoriesTagText = articleCategories.map(tags -> String.join(", ", tags)).orElse(null);
+    }
+
+    private void fetchContentFragmentData() {
+        Optional<Resource> fragmentResourceOptional = Optional.ofNullable(resourceResolver.getResource(authorContentFragment));
+
+        fragmentResourceOptional.ifPresent(fragmentResource -> Optional.ofNullable(fragmentResource.adaptTo(ContentFragment.class)).map(cfAuthor -> {
+            authorName = Optional.ofNullable(cfAuthor.getElement("authorName"))
+                    .map(ContentElement::getContent)
+                    .orElse(null);
+            authorDisplayPicture = Optional.ofNullable(cfAuthor.getElement("authorDisplayPicture"))
+                    .map(ContentElement::getContent)
+                    .orElse(null);
+            authorBio = Optional.ofNullable(cfAuthor.getElement("authorBio"))
+                    .map(ContentElement::getContent)
+                    .orElse(null);
+            return cfAuthor;
+        }));
+    }
+
+}

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/articlepage/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/articlepage/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="AEM Bootcamp Site Article Page"
+    sling:resourceSuperType="aem-bootcamp/components/page"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/articlepage/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/articlepage/.content.xml
@@ -2,4 +2,5 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="AEM Bootcamp Site Article Page"
-    sling:resourceSuperType="aem-bootcamp/components/page"/>
+    sling:resourceSuperType="aem-bootcamp/components/page"
+    componentGroup=".hidden"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/articlepage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/articlepage/_cq_dialog/.content.xml
@@ -1,23 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
-    xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="nt:unstructured"
     jcr:title="Article Page"
     sling:resourceType="cq/gui/components/authoring/dialog"
     extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties,granite.contexthub.configuration,cq.siteadmin.admin.properties]"
     helpPath="https://www.adobe.com/go/aem_cmp_page_v2"
-    mode="edit">
+    mode="edit"
+    trackingFeature="core-components:page:v2">
     <content
-        granite:class="cq-dialog-content-page"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="granite/ui/components/coral/foundation/container">
         <items jcr:primaryType="nt:unstructured">
             <tabs
-                granite:class="cq-siteadmin-admin-properties-tabs"
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="granite/ui/components/coral/foundation/tabs"
-                size="L">
+                sling:resourceType="granite/ui/components/coral/foundation/tabs">
                 <items jcr:primaryType="nt:unstructured">
                     <article
                         jcr:primaryType="nt:unstructured"
@@ -28,16 +24,23 @@
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/container">
                                 <items jcr:primaryType="nt:unstructured">
-                                    <articlecategories
+                                    <categories
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="cq/gui/components/coral/common/form/tagfield"
-                                        fieldLabel="Article Categories"
-                                        metaType="tags"
-                                        multiple="true"
-                                        name="./articlecategories"
-                                        rootPath="/content/cq:tags"
-                                        valueType="string[]" 
-                                        required="{Boolean}true" />
+                                        jcr:title="Article Categories"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <articlecategories
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/tagfield"
+                                                fieldLabel="Article Categories"
+                                                metaType="tags"
+                                                multiple="true"
+                                                name="./articlecategories"
+                                                rootPath="/content/cq:tags"
+                                                valueType="string[]" 
+                                                required="{Boolean}true" />
+                                        </items>
+                                    </categories>
                                 </items>
                             </column>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/articlepage/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/articlepage/_cq_dialog/.content.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Article Page"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties,granite.contexthub.configuration,cq.siteadmin.admin.properties]"
+    helpPath="https://www.adobe.com/go/aem_cmp_page_v2"
+    mode="edit">
+    <content
+        granite:class="cq-dialog-content-page"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                granite:class="cq-siteadmin-admin-properties-tabs"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                size="L">
+                <items jcr:primaryType="nt:unstructured">
+                    <article
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Article"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <articlecategories
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="cq/gui/components/coral/common/form/tagfield"
+                                        fieldLabel="Article Categories"
+                                        metaType="tags"
+                                        multiple="true"
+                                        name="./articlecategories"
+                                        rootPath="/content/cq:tags"
+                                        valueType="string[]" 
+                                        required="{Boolean}true" />
+                                </items>
+                            </column>
+                        </items>
+                    </article>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="article"
+    jcr:title="Article"
     jcr:description="This is Article component for AEM Bootcamp"
     componentGroup="AEM Bootcamp Site - Structure"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="article"
+    jcr:description="This is Article component for AEM Bootcamp"
+    componentGroup="AEM Bootcamp Site - Structure"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/_cq_dialog/.content.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root
+  xmlns:jcr="http://www.jcp.org/jcr/1.0"
+  xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+  xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+  xmlns:cq="http://www.day.com/jcr/cq/1.0"
+  xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+  jcr:primaryType="nt:unstructured"
+  jcr:title="article"
+  sling:resourceType="cq/gui/components/authoring/dialog"
+>
+  <content
+    jcr:primaryType="nt:unstructured"
+    sling:resourceType="granite/ui/components/coral/foundation/container"
+  >
+    <items jcr:primaryType="nt:unstructured">
+      <tabs
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/tabs"
+        maximized="{Boolean}false"
+      >
+        <items jcr:primaryType="nt:unstructured">
+          <tab1
+            jcr:primaryType="nt:unstructured"
+            jcr:title="General"
+            sling:resourceType="granite/ui/components/coral/foundation/container"
+            margin="{Boolean}true"
+          >
+            <items jcr:primaryType="nt:unstructured">
+              <columns
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                margin="{Boolean}true"
+              >
+                <items jcr:primaryType="nt:unstructured">
+                  <column
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                  >
+                    <items jcr:primaryType="nt:unstructured">
+                      <title
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                        fieldDescription="Digite um título"
+                        fieldLabel="Título"
+                        name="./title"
+                      />
+                      <file
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="cq/gui/components/authoring/dialog/fileupload"
+                        class="cq-droptarget"
+                        fileNameParameter="./fileName"
+                        fileReferenceParameter="./fileReference"
+                        mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
+                        name="./file"
+                        fieldLabel="Upload image"
+                        required="true"/>
+                      <description
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="cq/gui/components/authoring/dialog/richtext"
+                        name="./description"
+                        fieldLabel="Description"
+                        required="{Boolean}true"
+                        useFixedInlineToolbar="{Boolean}true"
+                      >
+                        <rtePlugins jcr:primaryType="nt:unstructured">
+                          <links
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <misctools
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <edit
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <findreplace
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <format
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <undo
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <subsuperscript
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <lists
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <justify
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                          <paraformat
+                            jcr:primaryType="nt:unstructured"
+                            features="*"
+                          />
+                        </rtePlugins>
+                        <uiSettings jcr:primaryType="nt:unstructured">
+                          <cui jcr:primaryType="nt:unstructured">
+                            <inline
+                              jcr:primaryType="nt:unstructured"
+                              toolbar="[format#bold,format#italic,#lists,links#modifylink,links#unlink,#paraformat]"
+                            >
+                              <popovers jcr:primaryType="nt:unstructured">
+                                <lists
+                                  jcr:primaryType="nt:unstructured"
+                                  items="[lists#unordered,lists#ordered,lists#outdent,lists#indent]"
+                                  ref="lists"
+                                />
+                                <paraformat
+                                  jcr:primaryType="nt:unstructured"
+                                  items="paraformat:getFormats:paraformat-pulldown"
+                                  ref="paraformat"
+                                />
+                              </popovers>
+                            </inline>
+                            <dialogFullScreen
+                              jcr:primaryType="nt:unstructured"
+                              toolbar="[edit#cut,edit#copy,edit#paste-default,edit#paste-plaintext,findreplace#find,findreplace#replace,format#bold,format#italic,format#underline,justify#justifyleft,justify#justifyright,links#modifylink,links#unlink,links#anchor,lists#ordered,lists#unordered,lists#indent,lists#outdent,misctools#specialchars,subsuperscript#subscript,subsuperscript#superscript,undo#undo,undo#redo,misctools#sourceedit]"
+                            >
+                            </dialogFullScreen>
+                          </cui>
+                        </uiSettings>
+                      </description>
+                      <fragmentPath
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="dam/cfm/components/cfpicker"
+                        name="./authorContentFragment"
+                        fieldDescription="Path to the Content Fragment to display."
+                        fieldLabel="Author"
+                        emptyText="Select Content Fragment with Author Info"
+                        pickerTitle="Select Content Fragment"
+                        rootPath="/content/dam"/>
+                    </items>
+                  </column>
+                </items>
+              </columns>
+            </items>
+          </tab1>
+        </items>
+      </tabs>
+    </items>
+  </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/_cq_dialog/.content.xml
@@ -6,7 +6,7 @@
   xmlns:cq="http://www.day.com/jcr/cq/1.0"
   xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
   jcr:primaryType="nt:unstructured"
-  jcr:title="article"
+  jcr:title="Article"
   sling:resourceType="cq/gui/components/authoring/dialog"
 >
   <content

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/article.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/structure/article/article.html
@@ -1,0 +1,46 @@
+<sly
+  data-sly-use.article="com.aembootcamp.core.models.ArticleModel"
+  data-sly-test.empty="${!article.description}"
+  data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+  data-sly-call="${template.placeholder @ isEmpty=empty}"
+/>
+<sly data-sly-test="${!empty}">
+  <article class="cmp-article">
+    <div class="cmp-article__img-container">
+      <img
+        src="${article.fileReference}"
+        loading="lazy"
+        class="cmp-article__img"
+        alt="${article.altText @ context='text'}"
+      />
+    </div>
+    <div class="cmp-article__tags">${article.categoriesTagText}</div>
+    <h1 class="cmp-article__title">
+      ${article.title || article.currentPage.title}
+    </h1>
+    <div
+      class="cmp-article__by-author-name"
+      data-sly-test.author="${article.authorName}"
+    >
+      By ${article.authorName}
+    </div>
+    <div class="cmp-article__text">
+      <div data-sly-text="${article.description @ context='html'}"></div>
+    </div>
+    <div class="cmp-article__author" data-sly-test="${author}">
+      <img
+        src=" ${article.authorDisplayPicture}"
+        loading="lazy"
+        class="cmp-article__author-picture"
+        alt="${article.altText @ context='text'}"
+      />
+      <div class="cmp-article__author-description">
+        <div class="cmp-article__author-name">${article.authorName}</div>
+        <div
+          class="cmp-article__author-bio"
+          data-sly-text="${article.authorBio @ context='html'}"
+        ></div>
+      </div>
+    </div>
+  </article>
+</sly>

--- a/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/templates/article/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/templates/article/initial/.content.xml
@@ -2,11 +2,11 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:lastModified="{Date}2024-06-25T16:35:51.754-05:00"
+        cq:lastModified="{Date}2024-06-26T16:44:11.849-05:00"
         cq:lastModifiedBy="admin"
         cq:template="/conf/aem-bootcamp/settings/wcm/templates/article"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="aem-bootcamp/components/page">
+        sling:resourceType="aem-bootcamp/components/articlepage">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="aem-bootcamp/components/container"
@@ -25,9 +25,9 @@
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="aem-bootcamp/components/container">
                 <article
-                    jcr:created="{Date}2024-06-25T16:35:51.751-05:00"
+                    jcr:created="{Date}2024-06-26T16:44:11.846-05:00"
                     jcr:createdBy="admin"
-                    jcr:lastModified="{Date}2024-06-25T16:35:51.751-05:00"
+                    jcr:lastModified="{Date}2024-06-26T16:44:11.846-05:00"
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="aem-bootcamp/components/structure/article"/>

--- a/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/templates/article/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/templates/article/structure/.content.xml
@@ -3,11 +3,11 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         cq:deviceGroups="[mobile/groups/responsive]"
-        cq:lastModified="{Date}2024-06-25T15:44:45.353-05:00"
+        cq:lastModified="{Date}2024-06-26T16:27:42.992-05:00"
         cq:lastModifiedBy="admin"
         cq:template="/conf/aem-bootcamp/settings/wcm/templates/article"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="aem-bootcamp/components/page">
+        sling:resourceType="aem-bootcamp/components/articlepage">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="aem-bootcamp/components/container"

--- a/ui.frontend/src/main/webpack/components/_article.scss
+++ b/ui.frontend/src/main/webpack/components/_article.scss
@@ -1,0 +1,71 @@
+.cmp-article {
+    padding: 0 6vw;
+    &__title {
+      font-weight: normal;
+      font-size: xx-large;
+      text-transform: capitalize;
+      font-weight: bold;
+    }
+    &__by-author-name {
+      font-size: large;
+      margin: 0;
+      text-transform: uppercase;
+    }
+    &__img-container {
+      display: flex;
+      justify-content: center;
+      max-height: 600px;
+    }
+    &__img {
+      object-fit: cover;
+      height: auto;
+      width: 100%;
+      aspect-ratio: 16/9;
+    }
+    &__tags {
+      font-style: italic;
+      color: rgb(206, 62, 62);
+    }
+    &__text {
+      text-transform: capitalize;
+    }
+    &__author {
+      display: flex;
+      margin: 30px 0;
+      gap: 24px;
+      padding-top: 30px;
+      border-top: solid 1px rgb(205, 204, 204);
+    }
+  
+    &__author-description {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+    &__author-picture {
+      height: 80px;
+      width: 80px;
+      border-radius: 100%;
+      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+    }
+    &__author-name {
+      font-size: x-large;
+      font-style: italic;
+      margin: 0;
+    }
+    &__author-bio {
+      margin: 0;
+      font-size: 14px;
+      color: grey;
+  
+      p {
+        margin: 0;
+      }
+    }
+  
+    @media (min-width: 1024px) {
+      padding: 0;
+      margin: 0 auto;
+      width: 1024px;
+    }
+  }


### PR DESCRIPTION
Article Component:
![image](https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170551914/16ad9022-e2ec-4e32-b805-ad10e2590ee9)

Author shall have the ability to configure Articles with the following features:
• Title: Core Title component (Baked in), Optional (Default - Page Title)
• Image: Core Image (Baked in), Required
• Description: Core Text (Baked in), Required
• Tags: Tag Field (Page properties)
![image](https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170551914/c96e61da-a940-485e-9325-00c3d22568da)

Create new tab only for article page template under page properties dialog. Add following
fields:
• Article Categories: tagpicker (Required)
![image](https://github.com/lflondonol92/prft-aem-bootcamp-latam-q2/assets/170551914/6cdc1d25-20c5-42af-bf1f-936de46ace08)

